### PR TITLE
feat(RouteTable): Public Subnet Route Table, IGW 연결

### DIFF
--- a/ksh/main.tf
+++ b/ksh/main.tf
@@ -28,3 +28,12 @@ module "igw" {
   source = "./modules/network/igw"
   vpc_id = module.vpc.vpc_id
 }
+
+module "public_route_table" {
+  source = "./modules/network/routetable"
+  vpc_id = var.vpc_id
+  igw_id = var.igw_id
+  public_subnet_id = var.public_subnet_id
+  project_name = var.project_name
+  common_tags = var.common_tags
+}

--- a/ksh/modules/network/routetable/main.tf
+++ b/ksh/modules/network/routetable/main.tf
@@ -1,0 +1,18 @@
+resource "aws_route_table" "public" {
+  vpc_id = var.vpc_id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project_name}-public-rt"
+  })
+}
+
+resource "aws_route" "public_internet_access" {
+  route_table_id = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id = var.igw_id
+}
+
+resource "aws_route_table_association" "public_subnet" {
+  subnet_id = var.public_subnet_id
+  route_table_id = aws_route_table.public.id
+}

--- a/ksh/modules/network/routetable/output.tf
+++ b/ksh/modules/network/routetable/output.tf
@@ -1,0 +1,9 @@
+output "route_table_id" {
+  description = "Created public route table ID"
+  value = aws_route_table.public.id
+}
+
+output "route_table_association_id" {
+  description = "Route Table Association ID"
+  value = aws_route_table_association.public_subnet.id
+}

--- a/ksh/modules/network/routetable/variables.tf
+++ b/ksh/modules/network/routetable/variables.tf
@@ -1,0 +1,25 @@
+variable "vpc_id" {
+  description = "VPC ID"
+  type = string
+}
+
+variable "igw_id" {
+  description = "IGW ID"
+  type = string
+}
+
+variable "public_subnet_id" {
+  description = "Public Subnet ID"
+  type = string
+}
+
+variable "project_name" {
+  description = "Project Name"
+  type = string
+}
+
+variable "common_tags" {
+  description = "Common Tags - All Resources"
+  type = map(string)
+  default = {}
+}

--- a/ksh/output.tf
+++ b/ksh/output.tf
@@ -13,3 +13,7 @@ output "private_subnet_id" {
 output "igw_id" {
   value = module.igw.igw_id
 }
+
+output "public_route_table_id" {
+  value = module.public_route_table.route_table_id
+}

--- a/ksh/variables.tf
+++ b/ksh/variables.tf
@@ -30,3 +30,12 @@ variable "private_subnet_cidr" {
 variable "availability_zones"{
   type = list(string)
 }
+
+variable "vpc_id" {}
+variable "igw_id" {}
+variable "public_subnet_id" {}
+variable "project_name" {}
+variable "common_tags" {
+  type = map(string)
+  default = {}
+}


### PR DESCRIPTION
### 🔨 작업 내용
- Public Subnet용 Route Table 생성 및 IGW 연결
- 모듈 변수 및 공통 태그 적용
- Private Subnet 연결은 별도 브랜치(NAT)에서 작업 예정

### 📄 참고 사항
- Terraform 모듈 초기화(terraform init) 후 적용 필요
- Public Subnet 인터넷 접근 가능