### PR TITLE
feat(NAT): Private Subnet NAT Gateway, RT 생성

### DIFF
--- a/ksh/main.tf
+++ b/ksh/main.tf
@@ -37,3 +37,13 @@ module "public_route_table" {
   project_name = var.project_name
   common_tags = var.common_tags
 }
+
+module "private_nat" {
+  source = "./modules/network/nat"
+  vpc_id = var.vpc_id
+  private_subnet_id = var.private_subnet_id
+  nat_eip_allocation_id = var.nat_eip_allocation_id
+  availability_zones = var.availability_zones
+  project_name = var.project
+  common_tags = var.tags
+}

--- a/ksh/modules/network/nat/main.tf
+++ b/ksh/modules/network/nat/main.tf
@@ -1,0 +1,28 @@
+resource "aws_nat_gateway" "nat" {
+  count = length(var.availability_zones)
+  allocation_id = var.nat_eip_allocation_id[count.index]
+  subnet_id = var.private_subnet_id[count.index]
+
+  tags = merge(var.common_tags, {Name = "${var.project_name}-nat-${count.index + 1}"})
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = var.vpc_id
+
+  tags = merge(var.common_tags, {
+    Name = "${var.project_name}-nat-${count.index + 1}"
+  })
+}
+
+resource "aws_route_table_association" "private_subnet" {
+  count = length(var.private_subnet_id)
+  subnet_id = var.private_subnet_id[count.index]
+  route_table_id = aws_route_table.private.id
+}
+
+resource "aws_route" "private_internet_access" {
+  count = length(var.private_subnet_id)
+  route_table_id = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id = aws_nat_gateway.nat[count.index].id
+}

--- a/ksh/modules/network/nat/output.tf
+++ b/ksh/modules/network/nat/output.tf
@@ -1,0 +1,9 @@
+output "nat_gateway_id" {
+  description = "Created NAT Gateway ID"
+  value = aws_nat_gateway.nat[*].id
+}
+
+output "private_route_table_id" {
+  description = "Private Route Table ID"
+  value = aws_route_table.private.id
+}

--- a/ksh/modules/network/nat/variables.tf
+++ b/ksh/modules/network/nat/variables.tf
@@ -1,0 +1,24 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "private_subnet_id" {
+  type = list(string)
+}
+
+variable "nat_eip_allocation_id" {
+  type = list(string)
+}
+
+variable "availability_zones" {
+  type = list(string)
+}
+
+variable "project_name" {
+  type = string
+}
+
+variable "common_tags" {
+  type    = map(string)
+  default = {}
+}

--- a/ksh/output.tf
+++ b/ksh/output.tf
@@ -17,3 +17,11 @@ output "igw_id" {
 output "public_route_table_id" {
   value = module.public_route_table.route_table_id
 }
+
+output "private_route_table_id" {
+  value = module.private_nat.private_route_table_id
+}
+
+output "nat_gateway_id" {
+  value = module.private_nat.private_route_table_id
+}

--- a/ksh/variables.tf
+++ b/ksh/variables.tf
@@ -31,11 +31,23 @@ variable "availability_zones"{
   type = list(string)
 }
 
-variable "vpc_id" {}
+variable "vpc_id" {
+  type = string
+}
+
 variable "igw_id" {}
 variable "public_subnet_id" {}
 variable "project_name" {}
 variable "common_tags" {
   type = map(string)
   default = {}
+}
+
+variable "private_subnet_id" {
+  type = list(string)
+}
+
+variable "nat_eip_allocation_id" {
+  type = list(string)
+  description = "EIP allocation ID - NAT Gateway"
 }


### PR DESCRIPTION
🔨 작업 내용
Private Subnet용 NAT Gateway 생성 및 연결
Private Route Table 생성 후 각 Private Subnet과 연결
0.0.0.0/0 트래픽 NAT Gateway를 통해 라우팅
모듈 변수 및 공통 태그 적용

📄 참고 사항
Public Subnet은 이미 IGW 연결 완료
Terraform 모듈 초기화 후 적용 필요
