### PR TITLE
feat(V-Endpoint): VPC Endpoint(S3)생성 > private subnet

### DIFF
--- a/ksh/main.tf
+++ b/ksh/main.tf
@@ -59,3 +59,13 @@ module "sg" {
   vpc_id = module.vpc.vpc_id
   my_ip = var.my_ip
 }
+
+#VPC Endpoint (S3)
+module "vpc_endpoint_s3" {
+  source = "./modules/network/vpcendpoint"
+  vpc_id = module.vpc.vpc_id
+  private_route_table_ids = [module.private_nat.private_route_table_id]
+  service_name = "com.amazonaws.ap-northeast-2.s3"
+  project_name = var.project_name
+  common_tags = var.tags
+}

--- a/ksh/modules/network/vpcendpoint/main.tf
+++ b/ksh/modules/network/vpcendpoint/main.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id = var.vpc_id
+  service_name = "com.amazonaws.${var.region}.s3"
+  route_table_ids = var.private_route_table_ids
+  vpc_endpoint_type = "Gateway"
+
+  tags = merge(var.common_tags, {Name = "${var.project_name}-s3-endpoint"})
+}

--- a/ksh/modules/network/vpcendpoint/output.tf
+++ b/ksh/modules/network/vpcendpoint/output.tf
@@ -1,0 +1,4 @@
+output "s3_vpc_endpoint_id" {
+  value = aws_vpc_endpoint.s3.id
+  description = "VPC Endpoint - S3"
+}

--- a/ksh/modules/network/vpcendpoint/variables.tf
+++ b/ksh/modules/network/vpcendpoint/variables.tf
@@ -1,0 +1,29 @@
+variable "vpc_id" {
+  type = string
+  description = "VPC ID - endpoint"
+}
+
+variable "private_route_table_ids" {
+  type = list(string)
+  description = "Private Subnet RT ID - VPC Endpoint"
+}
+
+variable "service_name" {
+  type = string
+  description = "VPC Endpoint - AWS service name"
+}
+
+variable "project_name" {
+  type = string
+  description = "Project Name - tagging"
+}
+
+variable "region" {
+  type = string
+  default = "ap-northeast-2"
+}
+
+variable "common_tags" {
+  type = map(string)
+  default = {}
+}

--- a/ksh/output.tf
+++ b/ksh/output.tf
@@ -39,3 +39,9 @@ output "sg_public_id" {
 output "sg_private_id" {
   value = module.sg.sg_private_id
 }
+
+#VPC Endpoint (S3)
+output "vpc_endpoint_s3_id" {
+  value = module.vpc_endpoint_s3.s3_vpc_endpoint_id
+  description = "Private Subnet S3 - VPC Endpoint ID"
+}


### PR DESCRIPTION
🔨 상세 작업 내용
Private Subnet용 S3 VPC Endpoint 모듈 생성
Root main.tf에서 VPC Endpoint 호출 및 output 추가

📄 참고 사항
Private Subnet EC2의 S3 접근은 VPC Endpoint 사용
향후 다른 AWS 서비스 접근 필요 시 Endpoint 추가 가능